### PR TITLE
Remove the undesired :end: emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Longest Objective-C Method Names
 * [139] copyFromBuffer:sourceOffset:sourceBytesPerRow:sourceBytesPerImage:sourceSize:toTexture:destinationSlice:destinationLevel:destinationOrigin:
 * [133] generateAmbientOcclusionTextureWithSize:raysPerSample:attenuationFactor:objectsToConsider:vertexAttributeNamed:materialPropertyNamed:
 * [129] workoutWithActivityType:startDate:endDate:workoutEvents:totalEnergyBurned:totalDistance:totalSwimmingStrokeCount:device:metadata:
-* [128] initRecurrenceWithFrequency:interval:daysOfTheWeek:daysOfTheMonth:monthsOfTheYear:weeksOfTheYear:daysOfTheYear:setPositions:end:
+* [128] initRecurrenceWithFrequency:interval:daysOfTheWeek:daysOfTheMonth:monthsOfTheYear:weeksOfTheYear:daysOfTheYear:setPositions:end&#8203;:
 
 Longest Objective-C Method Names (0/1 Parameter)
 ----------------


### PR DESCRIPTION
There's no nice way to escape emojis in GitHub-flavored markdown, but adding a zero-width space seems to fix it.